### PR TITLE
Add support for overwriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ git clone https://github.com/ellygaytor/trasheddit.git && cd trasheddit && pip3 
 
 ### Options
 
-| Option                      | Function                                        | Usage                                                                      |
-|-----------------------------|-------------------------------------------------|----------------------------------------------------------------------------|
-| `-k` or `--keep`            | Keep submissions younger than the inputted time | `-k 3M` will keep submissions younger than 3 months                        |
-| `-s` or `--skip-subreddits` | Skip entered subreddits                         | `-s askreddit -s python` will skip submissions in r/askreddit and r/python |
-| `d` or `--dry-run`          | Do a dry run                                    | `-d` will not actually delete any submissions                              |
+| Option                      | Function                                                               | Usage                                                                      |
+|-----------------------------|------------------------------------------------------------------------|----------------------------------------------------------------------------|
+| `-k` or `--keep`            | Keep submissions younger than the inputted time                        | `-k 3M` will keep submissions younger than 3 months                        |
+| `-o` or `--overwrite`       | Overwrite submissions before deleting them. This is highly recommended.| `-o` will fill a submission with garbage data before deleting it           |
+| `-s` or `--skip-subreddits` | Skip entered subreddits                                                | `-s askreddit -s python` will skip submissions in r/askreddit and r/python |
+| `d` or `--dry-run`          | Do a dry run                                                           | `-d` will not actually delete any submissions                              |
 
 
 ### Configuring Credentials

--- a/main.py
+++ b/main.py
@@ -11,28 +11,55 @@ from tqdm import tqdm
 @dataclass
 class PRAWConfig:
     """Class to store PRAW details"""
+
     client_id: str
     client_secret: str
     username: str
     password: str
 
 
-parser = argparse.ArgumentParser(description='Shred a reddit account.')
-parser.add_argument('username', metavar='username', type=str,
-                    help='username to shred')
-parser.add_argument('-k', '--keep', metavar="keep", help='Keep submissions younger than the inputted time',
-                    default="0s")
-parser.add_argument('-o', '--overwrite', help='Overwrite submissions before deletion to prevent caching',
-                    action="store_true")
-parser.add_argument('-s', '--skip-subreddits', action='append',
-                    help='Subreddits to skip', required=False)
+parser = argparse.ArgumentParser(description="Shred a reddit account.")
 parser.add_argument(
-    '-d', '--dry-run', help='Do not actually delete submissions', action="store_true")
+    "username", metavar="username", type=str, help="username to shred"
+)
+parser.add_argument(
+    "-k",
+    "--keep",
+    metavar="keep",
+    help="Keep submissions younger than the inputted time",
+    default="0s",
+)
+parser.add_argument(
+    "-o",
+    "--overwrite",
+    help="Overwrite submissions before deletion to prevent caching",
+    action="store_true",
+)
+parser.add_argument(
+    "-s",
+    "--skip-subreddits",
+    action="append",
+    help="Subreddits to skip",
+    required=False,
+)
+parser.add_argument(
+    "-d",
+    "--dry-run",
+    help="Do not actually delete submissions",
+    action="store_true",
+)
 
 args = parser.parse_args()
 
-seconds_per_unit = {"s": 1, "m": 60, "h": 3600,
-                    "d": 86400, "w": 604800, "M": 2629800, "y": 31557600}
+seconds_per_unit = {
+    "s": 1,
+    "m": 60,
+    "h": 3600,
+    "d": 86400,
+    "w": 604800,
+    "M": 2629800,
+    "y": 31557600,
+}
 
 
 def convert_to_seconds(s):
@@ -58,20 +85,23 @@ try:
     config = pickle.load(open(args.username + ".pickle", "rb"))
 except (OSError, IOError) as e:
     print(
-        "No configuration file found for '{}'. Please enter the PRAW configuration details now:".format(args.username))
+        "No configuration file found for '{}'. Please enter the PRAW configuration details now:".format(
+            args.username
+        )
+    )
     client_id = str(input("client_id: "))
     client_secret = str(input("client_secret: "))
     username = args.username
     password = str(input("password: "))
     config = PRAWConfig(client_id, client_secret, username, password)
-    pickle.dump(config, open(args.username + ".pickle", 'wb'))
+    pickle.dump(config, open(args.username + ".pickle", "wb"))
 
 reddit = praw.Reddit(
     client_id=config.client_id,
     client_secret=config.client_secret,
     user_agent="trasheddit",
     username=config.username,
-    password=config.password
+    password=config.password,
 )
 
 if args.overwrite:
@@ -81,14 +111,28 @@ if args.overwrite:
 submissions = []
 
 print("Getting and checking submissions...")
-for comment in tqdm((reddit.redditor(args.username).comments.new(limit=None)), desc="1000 most recent comments",
-                    unit=" comments"):
-    if not check_submission_date(comment) and not check_submission_subreddit(comment) and not args.dry_run:
+for comment in tqdm(
+    (reddit.redditor(args.username).comments.new(limit=None)),
+    desc="1000 most recent comments",
+    unit=" comments",
+):
+    if (
+        not check_submission_date(comment)
+        and not check_submission_subreddit(comment)
+        and not args.dry_run
+    ):
         submissions.append(comment)
 
-for post in tqdm((reddit.redditor(args.username).submissions.new(limit=None)), desc="1000 most recent posts",
-                 unit=" posts"):
-    if not check_submission_date(post) and not check_submission_subreddit(post) and not args.dry_run:
+for post in tqdm(
+    (reddit.redditor(args.username).submissions.new(limit=None)),
+    desc="1000 most recent posts",
+    unit=" posts",
+):
+    if (
+        not check_submission_date(post)
+        and not check_submission_subreddit(post)
+        and not args.dry_run
+    ):
         submissions.append(post)
 
 # If overwrite is enabled, overwrite the comments and posts that are to be deleted.
@@ -96,7 +140,7 @@ if args.overwrite:
     print("Overwriting submissions...")
     # Edit the comments
     for submission in tqdm(submissions):
-        submission.edit(os.urandom(1000).decode('latin1'))
+        submission.edit(os.urandom(1000).decode("latin1"))
     print("Waiting for edits to propagate (30 seconds)...")
     time.sleep(30)  # Sleep for 30 seconds to allow the edits to propagate.
 

--- a/main.py
+++ b/main.py
@@ -67,17 +67,17 @@ def convert_to_seconds(s):
     return float(s[:-1]) * seconds_per_unit[s[-1]]
 
 
-def check_submission_date(submission):
+def check_submission_date(submission_to_check):
     """Check if the passed in submission is past the cutoff"""
     now = time.time()
     cutoff = now - convert_to_seconds(args.keep)
-    return submission.created_utc >= cutoff
+    return submission_to_check.created_utc >= cutoff
 
 
-def check_submission_subreddit(submission):
+def check_submission_subreddit(submission_to_check):
     """Check if the passed in submission is in a subreddit that should be skipped"""
     if args.skip_subreddits is not None:
-        return submission.subreddit.display_name in args.skip_subreddits
+        return submission_to_check.subreddit.display_name in args.skip_subreddits
     return None
 
 


### PR DESCRIPTION
Add support for the `-o` option, which will fill submissions with random junk and wait a bit before deleting to make sure that submissions aren't viewable on "undelete" services.